### PR TITLE
Update argo-workflow.yaml

### DIFF
--- a/argo-workflow.yaml
+++ b/argo-workflow.yaml
@@ -4,24 +4,13 @@ metadata:
   generateName: nanoaod-argo-
 spec:
   entrypoint: nanoaod-argo
-  arguments:
-    parameters:
-    - name: nevents
-      value: 1000
-    - name: config
-      value: "data_cfg.py"
   volumes:
     - name: workdir
       hostPath:
         path: /mnt/data
         type: DirectoryOrCreate
-
   templates:
   - name: nanoaod-argo
-    inputs:
-      parameters:
-      - name: nevents
-      - name: config
     script:
       image: cmsopendata/cmssw_5_3_32 
       command: [sh]
@@ -33,9 +22,10 @@ spec:
         git clone git://github.com/cms-opendata-analyses/AOD2NanoAODOutreachTool  AOD2NanoAOD
         cd AOD2NanoAOD
         scram b -j8
-        eventline=$(grep maxEvents configs/{{inputs.parameters.config}})
-        sed -i "s/$eventline/process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32({{inputs.parameters.nevents}}) )/g" configs/{{inputs.parameters.config}}
-        cmsRun configs/{{inputs.parameters.config}}
+        nevents=10000
+        eventline=$(grep maxEvents configs/data_cfg.py)
+        sed -i "s/$eventline/process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32($nevents) )/g" configs/data_cfg.py
+        cmsRun configs/data_cfg.py
         cp output.root /mnt/vol/
         echo  ls -l /mnt/vol
         ls -l /mnt/vol


### PR DESCRIPTION
(closes #7 )
Argo workflow started failing, the problem can be traced to passing of the parameters. This PR removes the corresponding blocks in the workflow and gives the number of events directly in the `script:` part.